### PR TITLE
Tweak ResponseOutputStream

### DIFF
--- a/Ceen.Common/SyncAwaiter.cs
+++ b/Ceen.Common/SyncAwaiter.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Ceen.Common
+{
+    public sealed class SyncAwaiter : SynchronizationContext, IDisposable
+    {
+        private readonly BlockingCollection<(SendOrPostCallback callback, object state)> m_queue = new BlockingCollection<(SendOrPostCallback, object)>();
+
+        private SyncAwaiter() { }
+
+        public static void WaitSync(Func<Task> asyncOperation)
+        {
+            var prevContext = Current;
+
+            SyncAwaiter sync = null;
+            try
+            {
+                sync = new SyncAwaiter();
+                SetSynchronizationContext(sync);
+
+                var awaiter = asyncOperation().GetAwaiter();
+                sync.ExecuteCallbacks(awaiter);
+
+                // handle non-success result
+                awaiter.GetResult();
+            }
+            finally
+            {
+                SetSynchronizationContext(prevContext);
+                sync?.Dispose();
+            }
+        }
+
+        private void ExecuteCallbacks(TaskAwaiter awaiter)
+        {
+            while (!awaiter.IsCompleted)
+            {
+                var item = m_queue.Take();
+                item.callback(item.state);
+            }
+        }
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            m_queue.Add((d, state));
+        }
+
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            if (Current == this)
+            {
+	            // already on execution thread
+                d(state);
+                return;
+            }
+
+            var task = new Task(new Action<object>(d), state);
+            m_queue.Add((x => ((Task) x).RunSynchronously(), task));
+
+            task.Wait();
+        }
+
+        public override SynchronizationContext CreateCopy()
+        {
+            return this;
+        }
+
+        public void Dispose()
+        {
+            m_queue.Dispose();
+        }
+    }
+}

--- a/Ceen.Httpd/ResponseOutputStream.cs
+++ b/Ceen.Httpd/ResponseOutputStream.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using System.Threading;
+using Ceen.Common;
 
 namespace Ceen.Httpd
 {
@@ -110,7 +111,7 @@ namespace Ceen.Httpd
 		/// </summary>
 		public override void Flush()
 		{
-			FlushAsync(CancellationToken.None).ConfigureAwait(false).GetAwaiter().GetResult();
+			SyncAwaiter.WaitSync(() => FlushAsync(CancellationToken.None));
 		}
 
 		/// <summary>
@@ -188,8 +189,8 @@ namespace Ceen.Httpd
 		/// <param name="count">The number of bytes to write.</param>
 		public override void Write(byte[] buffer, int offset, int count)
 		{
-			//TODO: prevent async deadlock in case of Synchronized execution. Better should be refactored for sync Write
-			Task.Run(() => WriteAsync(buffer, offset, count)).Wait();
+            //TODO: prevent async deadlock in case of Synchronized execution. Better should be refactored for sync Write
+            SyncAwaiter.WaitSync(() => WriteAsync(buffer, offset, count));
 		}
 
 		/// <summary>
@@ -232,12 +233,12 @@ namespace Ceen.Httpd
 		/// <param name="disposing">If set to <c>true</c> disposing.</param>
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing)
+            if (disposing)
 			{
-				// prevent async deadlock in case of Synchronized execution
-				Task.Run(() => FlushAsync(CancellationToken.None)).Wait();
-				m_isDisposed = true;
-			}
+                // prevent async deadlock in case of Synchronized execution
+                SyncAwaiter.WaitSync(() => FlushAsync(CancellationToken.None));
+                m_isDisposed = true;
+            }
 		}
 
 		#endregion

--- a/Ceen.Httpd/ResponseOutputStream.cs
+++ b/Ceen.Httpd/ResponseOutputStream.cs
@@ -189,7 +189,7 @@ namespace Ceen.Httpd
 		/// <param name="count">The number of bytes to write.</param>
 		public override void Write(byte[] buffer, int offset, int count)
 		{
-            //TODO: prevent async deadlock in case of Synchronized execution. Better should be refactored for sync Write
+            //TODO: Better should be refactored for sync Write
             SyncAwaiter.WaitSync(() => WriteAsync(buffer, offset, count));
 		}
 
@@ -235,8 +235,7 @@ namespace Ceen.Httpd
 		{
             if (disposing)
 			{
-                // prevent async deadlock in case of Synchronized execution
-                SyncAwaiter.WaitSync(() => FlushAsync(CancellationToken.None));
+                Flush();
                 m_isDisposed = true;
             }
 		}


### PR DESCRIPTION
I'm using http server in single thread (through SynchonizationContext).
And getting deadlock on ResponseOutputStream disposing, because it tries to synchoniously flush written data and can't return to execution thread, as it is blocked by sync wait.

Also there was a bug in buffered write logic, In case of written data size >MAX_RESPONSE_BUFFER the chunk of data caused overflow has been written twice.