### PR TITLE
Bug fix for when using an IVirtualFileSystem

### DIFF
--- a/Ceen.Httpd/Handler/FileHandler.cs
+++ b/Ceen.Httpd/Handler/FileHandler.cs
@@ -347,6 +347,7 @@ namespace Ceen.Httpd.Handler
         {
             m_vfs = vfs ?? throw new ArgumentNullException(nameof(vfs));
             m_mimetypelookup = mimetypelookup ?? DefaultMimeTypes;
+            SourceFolder = string.Empty;
         }
 
         /// <summary>


### PR DESCRIPTION
I'm using Ceen.httpd in a .Net 6 project, making use of a custom IVirtualFileSystem.

When using the FileHandler() constructor that takes an IVirtualFileSystem, SourceFolder is left as null. Later on, when GetLocalPath() is called, an exception is thrown by Path.Combine() because of this.

This fix just sets SourceFolder to string.Empty within this constructor, fixing the issue.